### PR TITLE
use pycryptodome instead of pycrypto

### DIFF
--- a/pyps4/cli.py
+++ b/pyps4/cli.py
@@ -87,6 +87,7 @@ def main(args=None):
                         help='Print version')
 
     _sub = parser.add_subparsers(title='Commands')
+    _sub.required = True
 
     # search all devices
     subparser = _sub.add_parser('search', help='Search for PS4 devices')
@@ -121,6 +122,10 @@ def main(args=None):
     args = parser.parse_args(args)
 
     playstation = None
+
+    if not hasattr(args, 'func'):
+        parser.print_help()
+        sys.exit()
 
     if args.verbose:
         logging.basicConfig()

--- a/pyps4/connection.py
+++ b/pyps4/connection.py
@@ -6,8 +6,8 @@ import logging
 import socket
 
 from construct import (Bytes, Const, Int32ul, Padding, Struct)
-from Crypto.Cipher import AES, PKCS1_OAEP
-from Crypto.PublicKey import RSA
+from Cryptodome.Cipher import AES, PKCS1_OAEP
+from Cryptodome.PublicKey import RSA
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(name = name,
         install_requires = [
             'construct',
             'pycryptodome',
-            'pycryptodomex',
         ],
         entry_points = {
             'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(name = name,
         keywords = 'playstation sony ps4',
         install_requires = [
             'construct',
-            'pycrypto',
+            'pycryptodome',
         ],
         entry_points = {
             'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(name = name,
         install_requires = [
             'construct',
             'pycryptodome',
+            'pycryptodomex',
         ],
         entry_points = {
             'console_scripts': [


### PR DESCRIPTION
pycrypto is aparently an old component that is insecure and not updated, so the drop in replacement pycryptodome should be used

in hass 0.64 there is aparently some dependency problems as they install both versions in their docker image, but it looks like it should be fixed in 0.64.1 https://github.com/home-assistant/home-assistant/pull/12715
