### PR TITLE
fixed install dependency as pycryptodomex is only needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(name = name,
         keywords = 'playstation sony ps4',
         install_requires = [
             'construct',
-            'pycryptodome',
             'pycryptodomex',
         ],
         entry_points = {


### PR DESCRIPTION
in the docker hassio install the pycryptodome requirement is giving me problems, and as I can read in the docs we only use pycryptodomex now